### PR TITLE
New x509 Cert Schema, Handle upgrading schemas.

### DIFF
--- a/badger/v2/badger.go
+++ b/badger/v2/badger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"strings"
+	"time"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/options"
@@ -53,6 +54,18 @@ func (db *DB) Close() error {
 // CreateTable creates a token element with the 'bucket' prefix so that such
 // that their appears to be a table.
 func (db *DB) CreateTable(bucket []byte) error {
+	bk, err := badgerEncode(bucket)
+	if err != nil {
+		return err
+	}
+	return db.db.Update(func(txn *badger.Txn) error {
+		return errors.Wrapf(txn.Set(bk, []byte{}), "failed to create %s/", bucket)
+	})
+}
+
+// CreateX509CertificateTable creates a token element with the 'bucket' prefix so that such
+// that their appears to be a table.
+func (db *DB) CreateX509CertificateTable(bucket []byte) error {
 	bk, err := badgerEncode(bucket)
 	if err != nil {
 		return err
@@ -155,6 +168,17 @@ func (db *DB) Get(bucket, key []byte) (ret []byte, err error) {
 
 // Set stores the given value on bucket and key.
 func (db *DB) Set(bucket, key, value []byte) error {
+	bk, err := toBadgerKey(bucket, key)
+	if err != nil {
+		return errors.Wrapf(err, "error converting %s/%s to badgerKey", bucket, key)
+	}
+	return db.db.Update(func(txn *badger.Txn) error {
+		return errors.Wrapf(txn.Set(bk, value), "failed to set %s/%s", bucket, key)
+	})
+}
+
+// Set stores the given value on bucket and key.
+func (db *DB) SetX509Certificate(bucket, key, value []byte, notBefore time.Time, notAfter time.Time, province []string, locality []string, country []string, organization []string, organizationalUnit []string, commonName string, issuer string) error {
 	bk, err := toBadgerKey(bucket, key)
 	if err != nil {
 		return errors.Wrapf(err, "error converting %s/%s to badgerKey", bucket, key)

--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -47,6 +47,13 @@ func (db *DB) CreateTable(bucket []byte) error {
 	})
 }
 
+// CreateX509CertificateTable creates a bucket or an embedded bucket if it does not exists.
+func (db *DB) CreateX509CertificateTable(bucket []byte) error {
+	return db.db.Update(func(tx *bolt.Tx) error {
+		return db.createBucket(tx, bucket)
+	})
+}
+
 // DeleteTable deletes a root or embedded bucket. Returns an error if the
 // bucket cannot be found or if the key represents a non-bucket value.
 func (db *DB) DeleteTable(bucket []byte) error {
@@ -76,6 +83,17 @@ func (db *DB) Get(bucket, key []byte) (ret []byte, err error) {
 
 // Set stores the given value on bucket and key.
 func (db *DB) Set(bucket, key, value []byte) error {
+	return db.db.Update(func(tx *bolt.Tx) error {
+		b, err := db.getBucket(tx, bucket)
+		if err != nil {
+			return err
+		}
+		return errors.WithStack(b.Put(key, value))
+	})
+}
+
+// Set stores the given value on bucket and key.
+func (db *DB) SetX509Certificate(bucket, key, value []byte, notBefore time.Time, notAfter time.Time, province []string, locality []string, country []string, organization []string, organizationalUnit []string, commonName string, issuer string) error {
 	return db.db.Update(func(tx *bolt.Tx) error {
 		b, err := db.getBucket(tx, bucket)
 		if err != nil {

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -299,7 +299,7 @@ func (db *DB) CreateX509CertificateTable(bucket []byte) error {
 				return errors.Wrapf(err, "failed to create table %s", bucket)
 
 			}
-		} else { //Some other error occured.
+		} else { //Some other error occurred.
 			return errors.Wrapf(colErr, "failed to get length of columns %s", bucket)
 		}
 

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	// import mysql driver anonymously (just run the init)
 	_ "github.com/go-sql-driver/mysql"
@@ -57,12 +58,24 @@ func insertUpdateQry(bucket []byte) string {
 	return fmt.Sprintf("INSERT INTO `%s`(nkey, nvalue) VALUES(?,?) ON DUPLICATE KEY UPDATE nvalue = ?", bucket)
 }
 
+func insertUpdateX509CertificateQry(bucket []byte) string {
+	return fmt.Sprintf("INSERT INTO `%s`(nkey, nvalue, subjectNotBefore, subjectNotAfter, subjectState, subjectLocality, subjectCountry, subjectOrganization,subjectOrganizationalUnit, subjectCommonName, issuerDistinguishedName) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE nvalue = ?", bucket)
+}
+
 func delQry(bucket []byte) string {
 	return fmt.Sprintf("DELETE FROM `%s` WHERE nkey = ?", bucket)
 }
 
 func createTableQry(bucket []byte) string {
 	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s`(nkey VARBINARY(255), nvalue BLOB, PRIMARY KEY (nkey));", bucket)
+}
+
+func createX509CertsTableQry(bucket []byte) string {
+	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s`(nkey VARBINARY(255), nvalue BLOB, subjectNotBefore TIMESTAMP(0), subjectNotAfter TIMESTAMP(0), subjectState VARCHAR(255), subjectLocality VARCHAR(255), subjectCountry VARCHAR(255), subjectOrganization VARCHAR(255), subjectOrganizationalUnit VARCHAR(255),  subjectCommonName VARCHAR(255), issuerDistinguishedName VARCHAR(255), PRIMARY KEY (nkey));", bucket)
+}
+
+func alterX509CertsTableQry(bucket []byte) string {
+	return fmt.Sprintf("ALTER TABLE `%s` ADD subjectNotBefore TIMESTAMP(0), ADD subjectNotAfter TIMESTAMP(0), ADD subjectState VARCHAR(255), ADD subjectLocality VARCHAR(255), ADD subjectCountry VARCHAR(255), ADD subjectOrganization VARCHAR(255), ADD subjectOrganizationalUnit VARCHAR(255), ADD subjectCommonName VARCHAR(255), ADD issuerDistinguishedName VARCHAR(255);", bucket)
 }
 
 func deleteTableQry(bucket []byte) string {
@@ -92,6 +105,15 @@ func (db *DB) Set(bucket, key, value []byte) error {
 	return nil
 }
 
+// Set inserts the key and value into the given bucket(column).
+func (db *DB) SetX509Certificate(bucket, key, value []byte, notBefore time.Time, notAfter time.Time, province []string, locality []string, country []string, organization []string, organizationalUnit []string, commonName string, issuer string) error {
+	_, err := db.db.Exec(insertUpdateX509CertificateQry(bucket), key, value, notBefore, notAfter, strings.Join(province, " "), strings.Join(locality, " "), strings.Join(country, " "), strings.Join(organization, " "), strings.Join(organizationalUnit, " "), commonName, issuer, value)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set %s/%s", bucket, key)
+	}
+	return nil
+}
+
 // Del deletes a row from the database.
 func (db *DB) Del(bucket, key []byte) error {
 	_, err := db.db.Exec(delQry(bucket), key)
@@ -99,8 +121,7 @@ func (db *DB) Del(bucket, key []byte) error {
 }
 
 // List returns the full list of entries in a column.
-func (db *DB) List(bucket []byte) ([]*database.Entry, error) {
-	rows, err := db.db.Query(fmt.Sprintf("SELECT * FROM `%s`", bucket))
+func (db *DB) rowsToList(rows *sql.Rows, err error, bucket []byte) ([]*database.Entry, error) {
 	if err != nil {
 		estr := err.Error()
 		if strings.HasPrefix(estr, "Error 1146:") {
@@ -128,6 +149,17 @@ func (db *DB) List(bucket []byte) ([]*database.Entry, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error accessing row")
 	}
+	return entries, nil
+}
+
+// List returns the full list of entries in a column.
+func (db *DB) List(bucket []byte) ([]*database.Entry, error) {
+	rows, err := db.db.Query(fmt.Sprintf("SELECT * FROM `%s`", bucket))
+	entries, rowsErr := db.rowsToList(rows, err, bucket)
+	if rowsErr != nil {
+		return nil, errors.Wrap(rowsErr, "error converting row to list")
+	}
+
 	return entries, nil
 }
 
@@ -220,6 +252,10 @@ func (db *DB) Update(tx *database.Tx) error {
 			if _, err = sqlTx.Exec(insertUpdateQry(q.Bucket), q.Key, q.Value, q.Value); err != nil {
 				return rollback(errors.Wrapf(err, "failed to set %s/%s", q.Bucket, q.Key))
 			}
+		case database.SetX509Certificate:
+			if _, err = sqlTx.Exec(insertUpdateX509CertificateQry(q.Bucket), q.Key, q.Value, q.Value); err != nil {
+				return rollback(errors.Wrapf(err, "failed to set %s/%s", q.Bucket, q.Key))
+			}
 		case database.Delete:
 			if _, err = sqlTx.Exec(delQry(q.Bucket), q.Key); err != nil {
 				return rollback(errors.Wrapf(err, "failed to delete %s/%s", q.Bucket, q.Key))
@@ -247,6 +283,39 @@ func (db *DB) CreateTable(bucket []byte) error {
 	_, err := db.db.Exec(createTableQry(bucket))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create table %s", bucket)
+	}
+	return nil
+}
+
+// CreateX509CertificateTable creates a table in the database, and also handles upgrading the schema of the table if it doesn't match this new schema (to support users who upgrade to this version.)
+func (db *DB) CreateX509CertificateTable(bucket []byte) error {
+	rows, colErr := db.db.Query(fmt.Sprintf("SELECT * FROM `%s`", bucket))
+
+	//If it doesn't exist, we can create it the right way the first time.
+	if colErr != nil {
+		if strings.HasPrefix(colErr.Error(), "Error 1146:") { //Error 1146 means it doesn't exist. So we create it using the new schema.
+			_, err := db.db.Exec(createX509CertsTableQry(bucket))
+			if err != nil {
+				return errors.Wrapf(err, "failed to create table %s", bucket)
+
+			}
+		} else { //Some other error occured.
+			return errors.Wrapf(colErr, "failed to get length of columns %s", bucket)
+		}
+
+	} else { //The table exists, we need to check if our columns are present.
+		columnsList, colListErr := rows.Columns()
+		if colListErr != nil {
+			return errors.Wrapf(colErr, "failed to get length of columns %s", bucket)
+		}
+
+		// if len(rows.Columns()) == 2 we are using the old x509_certs schema, and we need to alter the table schema.
+		if len(columnsList) == 2 {
+			_, alterErr := db.db.Exec(alterX509CertsTableQry(bucket))
+			if alterErr != nil {
+				return errors.Wrapf(colErr, "failed to alter table to new schema %s", bucket)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This code defines the new schema, and adds methods that will be used in the smallstep/certificates application to store certificates in the future. This also handles upgrading the schema when users already have the tables created. I tested this on a local mysql instance to confirm the schema upgrade. Before and after screenshots uploaded.
![before](https://user-images.githubusercontent.com/12587979/132103917-1a6e77d2-19ee-4110-b62b-08b8eec0c04f.png)
![after](https://user-images.githubusercontent.com/12587979/132103922-755c59d2-6f13-4fcb-b688-7699679b2e5f.png)
