### PR TITLE
Tolerate more user inputs for mysql data source

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	// import mysql driver anonymously (just run the init)
 	"github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
 	"github.com/smallstep/nosql/database"


### PR DESCRIPTION
Quote database name to allow any valid mysql identifier to be used.
Do not require database to be set explicitly if it's in the DSN.
Do not require user to add trailing `&` when passing parameters.

Fixes https://github.com/smallstep/certificates/issues/743