### PR TITLE
Add Ping function to sql interface

### DIFF
--- a/badger/v1/badger.go
+++ b/badger/v1/badger.go
@@ -53,6 +53,11 @@ func (db *DB) Open(dir string, opt ...database.Option) (err error) {
 	return errors.Wrap(err, "error opening Badger database")
 }
 
+// Ping checks if the database is alive.
+func (db *DB) Ping() error {
+	return nil
+}
+
 // Close closes the DB database.
 func (db *DB) Close() error {
 	return errors.Wrap(db.db.Close(), "error closing Badger database")

--- a/badger/v2/badger.go
+++ b/badger/v2/badger.go
@@ -48,6 +48,11 @@ func (db *DB) Open(dir string, opt ...database.Option) (err error) {
 	return errors.Wrap(err, "error opening Badger database")
 }
 
+// Ping checks if the database is alive.
+func (db *DB) Ping() error {
+	return nil
+}
+
 // Close closes the DB database.
 func (db *DB) Close() error {
 	return errors.Wrap(db.db.Close(), "error closing Badger database")

--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -38,6 +38,11 @@ func (db *DB) Open(dataSourceName string, opt ...database.Option) (err error) {
 	return errors.WithStack(err)
 }
 
+// Ping checks if the database is alive.
+func (db *DB) Ping() error {
+	return nil
+}
+
 // Close closes the DB database.
 func (db *DB) Close() error {
 	return errors.WithStack(db.db.Close())

--- a/database/database.go
+++ b/database/database.go
@@ -110,6 +110,8 @@ type DB interface {
 	CreateTable(bucket []byte) error
 	// DeleteTable deletes a table or a bucket in the database.
 	DeleteTable(bucket []byte) error
+	// Ping checks if the database is still alive.
+	Ping() error
 }
 
 // Badger FileLoadingMode constants.

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -57,6 +57,11 @@ func (db *DB) Open(dataSourceName string, opt ...database.Option) error {
 	return nil
 }
 
+// Ping checks if the database is alive.
+func (db *DB) Ping() error {
+	return db.db.Ping()
+}
+
 // Close shutsdown the database driver.
 func (db *DB) Close() error {
 	return errors.WithStack(db.db.Close())

--- a/postgresql/postgresql.go
+++ b/postgresql/postgresql.go
@@ -58,6 +58,11 @@ func createDatabase(config *pgx.ConnConfig) error {
 	return nil
 }
 
+// Ping checks if the database is alive.
+func (db *DB) Ping() error {
+	return db.db.Ping()
+}
+
 // Open creates a Driver and connects to the database with the given address
 // and access details.
 func (db *DB) Open(dataSourceName string, opt ...database.Option) error {


### PR DESCRIPTION
We plan to run one (or more) step-ca instance(s) inside a k8s cluster in combination with a postgresql backend. To monitor the liveness of the instances a bit more precise I added a ping method to the sql interface. The usage in step-ca will be provided in a extra PR 😉 