### PR TITLE
Don't use select *

### DIFF
--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -117,7 +117,7 @@ func (db *DB) Del(bucket, key []byte) error {
 
 // List returns the full list of entries in a column.
 func (db *DB) List(bucket []byte) ([]*database.Entry, error) {
-	rows, err := db.db.Query(fmt.Sprintf("SELECT * FROM `%s`", bucket))
+	rows, err := db.db.Query(fmt.Sprintf("SELECT nkey, nvalue FROM `%s`", bucket))
 	if err != nil {
 		estr := err.Error()
 		if strings.HasPrefix(estr, "Error 1146") {

--- a/postgresql/postgresql.go
+++ b/postgresql/postgresql.go
@@ -104,7 +104,7 @@ func (db *DB) Close() error {
 }
 
 func getAllQry(bucket []byte) string {
-	return fmt.Sprintf("SELECT * FROM %s", quoteIdentifier(string(bucket)))
+	return fmt.Sprintf("SELECT nkey, nvalue FROM %s", quoteIdentifier(string(bucket)))
 }
 
 func getQry(bucket []byte) string {


### PR DESCRIPTION
<!---
Please provide answers in the spaces below each prompt, where applicable.
Not every PR requires responses for each prompt.
Use your discretion.
-->
#### Name of feature:

#### Pain or issue this feature alleviates:
All other queries select only required fields, but `getAllQry` uses `SELECT *`. I want to add columns to the nosql-created tables and update them via database triggers, but SELECT * prevents this.

#### Why is this important to the project (if not answered above):

#### Is there documentation on how to use this feature? If so, where?

#### In what environments or workflows is this feature supported?

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

#### Supporting links/other PRs/issues:

💔Thank you!
